### PR TITLE
convert to floating point to make the comparison

### DIFF
--- a/lib/eps/evaluators/lightgbm.rb
+++ b/lib/eps/evaluators/lightgbm.rb
@@ -92,9 +92,9 @@ module Eps
             when "in"
               node.value.include?(v)
             when "greaterThan"
-              v > node.value
+              v > node.value.to_f
             when "lessOrEqual"
-              v <= node.value
+              v <= node.value.to_f
             else
               raise "Unknown operator: #{node.operator}"
             end


### PR DESCRIPTION
I have an integer field that sometimes, but not always, triggers this error.  It looks like the comparison is reading a string from the pmml file and trying to compare against an int value.  The following change fixes my issue but I'm not sure if it causes issues in other places. 

```
/Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:97:in `<=': comparison of Integer with String failed (ArgumentError)
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:97:in `matches?'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:106:in `node_score'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:108:in `block in node_score'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:107:in `each'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:107:in `node_score'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:69:in `block (2 levels) in sum_trees'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:68:in `each'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:68:in `block in sum_trees'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:66:in `map'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:66:in `sum_trees'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/evaluators/lightgbm.rb:35:in `predict'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/base_estimator.rb:81:in `_predict'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/base_estimator.rb:12:in `predict'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/model.rb:60:in `public_send'
	from /Users/frank.stratton/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/eps-0.3.8/lib/eps/model.rb:60:in `method_missing'
	from test.rb:6:in `<top (required)>'```